### PR TITLE
feat(filter): filter to hosts/regions that can fit flavor

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,4 +3,4 @@ moto==0.4.1
 nose==1.3.7
 mock==1.3.0
 python-novaclient==3.2.0
--e git+ssh://git@github.com/NCI-GDC/signpost.git@9d48b163d47cf059b9ba38a1b4562b2809f4ad2e#egg=signpost
+-e git+https://github.com/NCI-GDC/signpost.git@9d48b163d47cf059b9ba38a1b4562b2809f4ad2e#egg=signpost

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 apache-libcloud==0.15.1
 boto>=2.36.0
 python-dateutil==2.4.2
--e git+ssh://git@github.com/NCI-GDC/python-signpostclient.git@ebc91a5f8343e8f4cb2caefc523b9ad3a1eb7c6c#egg=signpostclient
+-e git+https://github.com/NCI-GDC/python-signpostclient@ebc91a5f8343e8f4cb2caefc523b9ad3a1eb7c6c#egg=signpostclient


### PR DESCRIPTION
- Add option to restrict regions by regex
- Fixes filtering of outputs when only -o totals is specified
- Pulls services into separate cli flag

```
python nova_status.py -h
usage: nova_status.py [-h] [-o {cores,disk,ram,all,totals,maxes}] [-s]
                      [-r REGION] [-f FLAVOR_FITS]
                      [{1,2,all}]

positional arguments:
  {1,2,all}             availability zone to use

optional arguments:
  -h, --help            show this help message and exit
  -o {cores,disk,ram,all,totals,maxes}, --output {cores,disk,ram,all,totals,maxes}
                        If not 'all' include any output types to show.
  -s, --services        Include list of services running per host
  -r REGION, --region REGION
                        Region regex (e.g. `compute_1`)
  -f FLAVOR_FITS, --flavor-fits FLAVOR_FITS
                        Filter hosts out that flavor can't fit on
```

r? @madopal 