### PR TITLE
Update ndg-https client to latest version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
         'setuptools==30.1.0',
         'xmltodict==0.9.2',
         'pyOpenSSL==16.2.0',
-        'ndg-httpsclient==0.4.2',
-        'openpyxl==2.4.0'
+        'openpyxl==2.4.0',
+        'ndg-httpsclient==0.4.3'
     ],
 )


### PR DESCRIPTION
Does solve the crypto error during pip install on a tungsten deploy (link)[https://github.com/cedadev/ndg_httpsclient/issues/5#issuecomment-244320109]