### PR TITLE
chore: Update pin in signpostclient for new requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 xmltodict==0.9.2
 boto>=2.36.0
 python-dateutil==2.4.2
--e git+https://github.com/NCI-GDC/python-signpostclient@ebc91a5f8343e8f4cb2caefc523b9ad3a1eb7c6c#egg=signpostclient
+-e git+https://github.com/NCI-GDC/python-signpostclient@ca686f55772e9a7f839b4506090e7d2bb0de5f15#egg=signpostclient


### PR DESCRIPTION
The old hash pointed to an old commit where we bumped the version to 2.6.0. This one points to the new version of requests.

https://github.com/NCI-GDC/python-signpostclient/commit/ebc91a5f8343e8f4cb2caefc523b9ad3a1eb7c6c