### PR TITLE
use setuptools_scm to set version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,10 @@ from setuptools import setup
 
 setup(
     name="cdisutils",
-    version="0.1.1",
+    use_scm_version={
+        'local_scheme': 'dirty-tag',
+    },
+    setup_requires=['setuptools_scm'],
     description="Miscellaneous utilities useful for interaction with CDIS systems.",
     license="Apache",
     packages=["cdisutils"],


### PR DESCRIPTION
Update `setup.py` to set the package version using `setuptools_scm`. I was gonna set the `version` to `1.5.0` on the release branch, but this is more like how we'll want to do things in the future. I'll release/tag after this is merged.