### PR TITLE
fix(load_creds): fix boto3manger setup steps

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2020-08-26T01:57:48Z",
+  "generated_at": "2021-05-24T21:16:05Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -41,7 +41,7 @@
       {
         "hashed_secret": "62cdb7020ff920e5aa642c3d4066950dd1f01f4d",
         "is_verified": false,
-        "line_number": 171,
+        "line_number": 172,
         "type": "Secret Keyword"
       }
     ],

--- a/cdisutils/storage3.py
+++ b/cdisutils/storage3.py
@@ -110,6 +110,7 @@ def load_creds():
     }
     s3_endpoint_defaults = {
         "ceph": "ceph.service.consul",
+        "cephb" : "gdc-cephb-objstore.osdc.io",
         "cleversafe": "cleversafe.service.consul",
         "aws": "s3-external-1.amazonaws.com",
         "jamboree": "gdc-accessors-jamboree.osdc.io",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md") as readme_in:
 
 setup(
     name="cdisutils",
-    setup_requires=["setuptools_scm"],
+    setup_requires=["setuptools_scm<6"],
     use_scm_version={"local_scheme": "dirty-tag"},
     author="Center for Translational Data Science",
     author_email="support@nci-gdc.datacommons.io",


### PR DESCRIPTION
Boto3Manager loads creds from environment variables if they exist. cephb was missing from the list of potential object storage profiles which was causing issues with the environment variable parsing step.