### PR TITLE
fix pyyaml deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         "boto3~=1.9",
         "future>=0.16,<1.0",
         "python-dateutil~=2.4",
-        "PyYAML>=3.11<6.0",
+        "PyYAML>=3.11,<6.0",
         "six~=1.11",
         "urllib3~=1.0",
     ],


### PR DESCRIPTION
Fixes typo in version range definition for PyYaml, for some reason this has always worked but started failing recently for graphmanager. See sample log https://app.travis-ci.com/github/NCI-GDC/graphmanager/jobs/595770424#L321